### PR TITLE
fix: onPageChanged enables _autoplay

### DIFF
--- a/lib/src/onboarding/onboarding_internal_controller.dart
+++ b/lib/src/onboarding/onboarding_internal_controller.dart
@@ -42,8 +42,10 @@ class OnboardingInternalController {
   void onPageChanged(int index) {
     _currentPage = index;
     _controller?.pageChanged?.call(index);
-    stopTimer();
-    _initializeTimer();
+    if (_autoplay) {
+      stopTimer();
+      _initializeTimer();
+    }
   }
 
   void initialize() {


### PR DESCRIPTION
Dentro do método `initialize()` ele verifica se `_autoplay` está habilitado antes de inicializar o timer.
Acontece que a mesma validação não é executada dentro de `onPageChanged`,  então o timer é inicializado e o Onboard segue como se autoplay estivesse habilitado.